### PR TITLE
Simplifying

### DIFF
--- a/bashScript/showState.sh
+++ b/bashScript/showState.sh
@@ -10,7 +10,7 @@ if (( $# < 1 )); then
   exit
 fi
 address="10.12.114.181:3000"
-on=$(echo $(curl -s -X GET -H "Content-Type:application/json" http://$address/api/state/get/) | grep -oP "$1.*?}" | grep -oP 'state.*?}' | grep -oP ':".*?"' | grep -o 'on')
+on=$(echo $(curl -s -X GET -H "Content-Type:application/json" http://$address/api/state/get/) | grep -oE "$1.*?}" | grep -oE 'state.*?}' | grep -oE ':".*?"' | grep -o 'on')
 if [ X"$on" == X"" ]; then
   echo "$1's state is currently off"
 else

--- a/bashScript/showState.sh
+++ b/bashScript/showState.sh
@@ -10,9 +10,5 @@ if (( $# < 1 )); then
   exit
 fi
 address="10.12.114.181:3000"
-on=$(echo $(curl -s -X GET -H "Content-Type:application/json" http://$address/api/state/get/) | grep -oE "$1.*?}" | grep -oE 'state.*?}' | grep -oE ':".*?"' | grep -o 'on')
-if [ X"$on" == X"" ]; then
-  echo "$1's state is currently off"
-else
-  echo "$1's state is currently on"
-fi
+state=$(echo $(curl -s -X GET -H "Content-Type:application/json" http://$address/api/state/get/) | grep -o "$1[^}]*}" | grep -o 'state[^}]*}' | grep -o ':".*"' | grep -o 'o[^\"]*')
+echo "$1's state is currently $state"

--- a/bashScript/toggleState.sh
+++ b/bashScript/toggleState.sh
@@ -10,7 +10,7 @@ if (( $# < 1 )); then
   exit
 fi
 address="10.12.114.181:3000"
-on=$(echo $(curl -s -X GET -H "Content-Type:application/json" http://$address/api/state/get/) | grep -oP "$1.*?}" | grep -oP 'state.*?}' | grep -oP ':".*?"' | grep -o 'on')
+on=$(echo $(curl -s -X GET -H "Content-Type:application/json" http://$address/api/state/get/) | grep -oE "$1.*?}" | grep -oE 'state.*?}' | grep -oE ':".*?"' | grep -o 'on')
 old="on";  new="off"
 if [ X"$on" == X"" ]; then
   old="off"; new="on"

--- a/bashScript/toggleState.sh
+++ b/bashScript/toggleState.sh
@@ -10,10 +10,10 @@ if (( $# < 1 )); then
   exit
 fi
 address="10.12.114.181:3000"
-on=$(echo $(curl -s -X GET -H "Content-Type:application/json" http://$address/api/state/get/) | grep -oE "$1.*?}" | grep -oE 'state.*?}' | grep -oE ':".*?"' | grep -o 'on')
-old="on";  new="off"
-if [ X"$on" == X"" ]; then
-  old="off"; new="on"
+state=$(echo $(curl -s -X GET -H "Content-Type:application/json" http://$address/api/state/get/) | grep -o "$1[^}]*}" | grep -o 'state[^}]*}' | grep -o ':".*"' | grep -o 'o[^\"]*')
+new="off"
+if [ X"$state" == X"off" ]; then
+  new="on"
 fi
 curl -X PUT -d "{\"state\":\"$new\"}" -H "Content-Type:application/json" "http://$address/api/state/set/$1"
-echo "$1's state from '$old' to '$new'"
+echo "$1's state from '$state' to '$new'"

--- a/bashScript/toggleState.sh
+++ b/bashScript/toggleState.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# getting results from REST API
+# check if params are available
 if (( $# < 1 )); then
   echo "Skript toggles the current state of presence."; echo ""
   echo "Usage:"
@@ -9,7 +9,16 @@ if (( $# < 1 )); then
   echo "    ./toggleState dogi 10.12.114.181:3000"
   exit
 fi
+# set address or read it from param
 address="10.12.114.181:3000"
+if [ X"$2" != X"" ]; then
+  two=$(echo $2 | grep -oE "([0-9]{1,3}\.){,3}([0-9]{1,3}):[0-9]{1,5}")
+  echo $two
+  if [ X"" != "$two" ]; then
+    address="$2"
+  fi
+fi
+# get state of user set in param
 state=$(echo $(curl -s -X GET -H "Content-Type:application/json" http://$address/api/state/get/) | grep -o "$1[^}]*}" | grep -o 'state[^}]*}' | grep -o ':".*"' | grep -o 'o[^\"]*')
 new="off"
 if [ X"$state" == X"off" ]; then


### PR DESCRIPTION
Works on Mac, LinuxMint and Ubuntu; probably also on Debian and other distros.
No NodeJS, jsawk or jq needed on the client side anymore as grep does the job with POSIX-support.
Simplified code with less lines and less downloads neccessary.
Additionally conky support is available here for Linux: https://github.com/jhamfler/awesome/tree/master/.conkyskripte
